### PR TITLE
Add config file and token limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 env/
 
 # Files
+*.json
 *.md
 !README.md

--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ This repository contains a simple Python script that lets two local language mod
    ```bash
    pip install -r requirements.txt
    ```
-2. Edit `config.json` to adjust the models (`model_a` and `model_b`), the starting prompt, the number of conversation turns, or the output file name.
+2. Add a `config.json` to adjust the models (`model_a` and `model_b`), the starting prompt, the number of conversation turns, or the output file name. You can copy the `config.json.example`.
+   ```bash
+   cp config.json.example config.json
+   ```
+
 3. Run the script:
    ```bash
    python script.py

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository contains a simple Python script that lets two local language mod
    ```bash
    pip install -r requirements.txt
    ```
-2. Optionally edit `script.py` to adjust the models (`MODEL_A` and `MODEL_B`) or the starting prompt.
+2. Edit `config.json` to adjust the models (`model_a` and `model_b`), the starting prompt, or the maximum number of tokens returned per response.
 3. Run the script:
    ```bash
    python script.py
@@ -23,6 +23,7 @@ This repository contains a simple Python script that lets two local language mod
 
 ## Project Files
 
+- `config.json` – stores model names, the initial prompt, and token limits.
 - `script.py` – orchestrates the conversation between the two models.
 - `requirements.txt` – lists the Python dependency.
 - `chat_history.md` – created when the script runs and stores the dialogue.

--- a/README.md
+++ b/README.md
@@ -14,17 +14,17 @@ This repository contains a simple Python script that lets two local language mod
    ```bash
    pip install -r requirements.txt
    ```
-2. Edit `config.json` to adjust the models (`model_a` and `model_b`), the starting prompt, or the maximum number of tokens returned per response.
+2. Edit `config.json` to adjust the models (`model_a` and `model_b`), the starting prompt, the number of conversation turns, or the output file name.
 3. Run the script:
    ```bash
    python script.py
    ```
-4. Conversation turns are logged to `chat_history.md` in Markdown format.
+4. Conversation turns are logged to the file specified by `chat_history` in `config.json`.
 
 ## Project Files
 
-- `config.json` – stores model names, the initial prompt, and token limits.
+- `config.json` – stores model names, the initial prompt, iteration count, and output file location.
 - `script.py` – orchestrates the conversation between the two models.
 - `requirements.txt` – lists the Python dependency.
-- `chat_history.md` – created when the script runs and stores the dialogue.
+- history file (default `chat_history.md`) – created when the script runs and stores the dialogue.
 

--- a/config.json
+++ b/config.json
@@ -2,5 +2,6 @@
   "model_a": "qwen3:latest",
   "model_b": "qwen3:latest",
   "initial_prompt": "Hi! How are you?",
-  "max_tokens": 200
+  "iterations": 100,
+  "chat_history": "chat_history.md"
 }

--- a/config.json
+++ b/config.json
@@ -1,0 +1,6 @@
+{
+  "model_a": "qwen3:latest",
+  "model_b": "qwen3:latest",
+  "initial_prompt": "Hi! How are you?",
+  "max_tokens": 200
+}

--- a/config.json
+++ b/config.json
@@ -1,7 +1,0 @@
-{
-  "model_a": "qwen3:latest",
-  "model_b": "qwen3:latest",
-  "initial_prompt": "Hi! How are you?",
-  "iterations": 100,
-  "chat_history": "chat_history.md"
-}

--- a/config.json.example
+++ b/config.json.example
@@ -1,0 +1,7 @@
+{
+  "model_a": "qwen3:latest",
+  "model_b": "qwen3:latest",
+  "initial_prompt": "Hi! How are you?",
+  "iterations": 100,
+  "chat_history": "chat_history.md"
+}

--- a/script.py
+++ b/script.py
@@ -1,12 +1,18 @@
+import json
 import requests
 import re
 
 OLLAMA_HOST = "http://localhost:11434"
-# MODEL_A = "llama3.2"  # Replace with your model A name
-# MODEL_B = "phi4-mini"  # Replace with your model B name
-MODEL_A = MODEL_B = "qwen3:latest"
-# MODEL_A = MODEL_B = "deepseek-r1:1.5b"
-INITIAL_PROMPT = "Hi! How are you?"  # Replace with your desired prompt
+
+# Load configuration for models and prompts
+CONFIG_PATH = "config.json"
+with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+    _cfg = json.load(f)
+
+MODEL_A = _cfg.get("model_a", "qwen3:latest")
+MODEL_B = _cfg.get("model_b", "qwen3:latest")
+INITIAL_PROMPT = _cfg.get("initial_prompt", "Hi! How are you?")
+MAX_TOKENS = int(_cfg.get("max_tokens", 0))  # 0 for unlimited
 
 
 def remove_think_tags(text):
@@ -19,7 +25,12 @@ def remove_think_tags(text):
 
 def query_ollama(model, prompt, history):
     url = f"{OLLAMA_HOST}/v1/chat/completions"
-    payload = {"model": model, "messages": history + [{"role": "user", "content": prompt}]}
+    payload = {
+        "model": model,
+        "messages": history + [{"role": "user", "content": prompt}],
+    }
+    if MAX_TOKENS > 0:
+        payload["options"] = {"num_predict": MAX_TOKENS}
     response = requests.post(url, json=payload)
     response.raise_for_status()
     data = response.json()


### PR DESCRIPTION
## Summary
- load model names and prompt from `config.json`
- add optional token cap for each completion
- document new config file usage

## Testing
- `python -m py_compile script.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68591cfe53888328b87a15ebfa694edd