### PR TITLE
Enable streaming output for Ollama responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This repository contains a simple Python script that lets two local language mod
    ```bash
    python script.py
    ```
+   The assistant responses will stream to the console as they are generated.
 4. Conversation turns are logged to the file specified by `chat_history` in `config.json`.
 
 ## Project Files

--- a/script.py
+++ b/script.py
@@ -36,9 +36,11 @@ def query_ollama(model, prompt, history):
     response.raise_for_status()
 
     collected = []
-    for line in response.iter_lines(decode_unicode=True):
-        if not line:
+    for raw_line in response.iter_lines(decode_unicode=False):
+        if not raw_line:
             continue
+        # decode explicitly as UTF-8 to avoid issues with autodetection
+        line = raw_line.decode("utf-8", errors="replace")
 
         # Remove SSE "data:" prefix if present
         if line.startswith("data:"):

--- a/script.py
+++ b/script.py
@@ -14,6 +14,7 @@ MODEL_B = _cfg.get("model_b", "qwen3:latest")
 INITIAL_PROMPT = _cfg.get("initial_prompt", "Hi! How are you?")
 ITERATIONS = int(_cfg.get("iterations", 100))
 CHAT_HISTORY_FILE = _cfg.get("chat_history", "chat_history.md")
+STREAM = eval(_cfg.get("stream", "False"))
 
 
 def remove_think_tags(text):
@@ -26,56 +27,63 @@ def remove_think_tags(text):
 
 def query_ollama(model, prompt, history):
     url = f"{OLLAMA_HOST}/v1/chat/completions"
+    history.append({"role": "user", "content": prompt})
     payload = {
         "model": model,
-        "messages": history + [{"role": "user", "content": prompt}],
-        "stream": True,
+        "messages": history,
+        "stream": STREAM,
     }
 
-    response = requests.post(url, json=payload, stream=True)
+    response = requests.post(url, json=payload, stream=STREAM)
     response.raise_for_status()
 
-    collected = []
-    for raw_line in response.iter_lines(decode_unicode=False):
-        if not raw_line:
-            continue
-        # decode explicitly as UTF-8 to avoid issues with autodetection
-        line = raw_line.decode("utf-8", errors="replace")
+    if not STREAM:
+        data = response.json()
+        content = data['choices'][0]['message']['content']
+    else:
+        collected = []
+        for raw_line in response.iter_lines(decode_unicode=False):
+            
+            if not raw_line:
+                continue
 
-        # Remove SSE "data:" prefix if present
-        if line.startswith("data:"):
-            line = line[len("data:"):].strip()
-        if line == "[DONE]":
-            break
+            # decode explicitly as UTF-8 to avoid issues with autodetection
+            line = raw_line.decode("utf-8", errors="replace")
 
-        try:
-            data = json.loads(line)
-        except json.JSONDecodeError:
-            # Skip malformed JSON but keep collecting
-            print(f"\n[warn] bad json chunk: {line}", flush=True)
-            continue
+            # Remove SSE "data:" prefix if present
+            if line.startswith("data:"):
+                line = line[len("data:"):].strip()
+            if line == "[DONE]":
+                break
 
-        # handle both openai-compatible and ollama native streaming formats
-        token = ""
-        if "choices" in data:
-            delta = data["choices"][0].get("delta", {})
-            token = delta.get("content", "")
-        elif "message" in data:
-            token = data["message"].get("content", "")
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                # Skip malformed JSON but keep collecting
+                print(f"\n[warn] bad json chunk: {line}", flush=True)
+                continue
 
-        if token:
-            print(token, end="", flush=True)
-            collected.append(token)
+            # handle both openai-compatible and ollama native streaming formats
+            token = ""
+            if "choices" in data:
+                delta = data["choices"][0].get("delta", {})
+                token = delta.get("content", "")
+            elif "message" in data:
+                token = data["message"].get("content", "")
 
-        if data.get("done") or data.get("choices", [{}])[0].get("finish_reason"):
-            break
+            if token:
+                print(token, end="", flush=True)
+                collected.append(token)
 
-    print()
-    content = "".join(collected)
+            if data.get("done") or data.get("choices", [{}])[0].get("finish_reason"):
+                break
+
+        print()
+        content = "".join(collected)
+
     content = remove_think_tags(content)
 
     # Update conversation history so models keep context
-    history.append({"role": "user", "content": prompt})
     history.append({"role": "assistant", "content": content})
 
     return content, history
@@ -86,8 +94,8 @@ def main(initial_prompt=INITIAL_PROMPT):
     with open(CHAT_HISTORY_FILE, "a", encoding="utf-8") as f:
             f.write(f"### Loop 0\n")
             f.write(f"**Initial prompot**:\n{initial_prompt}\n\n")
-    history_a = list()
-    history_b = list()
+    history_a = [{"user": "system", "content": "Reply in the same language as the prompt"}]
+    history_b = [{"user": "system", "content": "Reply in the same language as the prompt"}]
     response_b = initial_prompt
 
     for i in range(1, ITERATIONS + 1):


### PR DESCRIPTION
## Summary
- stream chat completion tokens as they arrive
- document that responses stream to the console

## Testing
- `python -m py_compile script.py`
- `python script.py --help` *(fails: FileNotFoundError: 'config.json')*


------
https://chatgpt.com/codex/tasks/task_b_685edd595a28832884355f75430269ff